### PR TITLE
⚡ Optimize article scraping with concurrency

### DIFF
--- a/src/getArticles.ts
+++ b/src/getArticles.ts
@@ -1,18 +1,28 @@
-import { BASE_URL } from "./constants";
+import { BASE_URL, CHUNK_SIZE } from "./constants";
 import type { Article } from "./types";
-import { extractArticlesFromRow, generateUrls, getPageRows } from "./utils/utils";
+import {
+	chunkArray,
+	extractArticlesFromRow,
+	generateUrls,
+	getPageRows,
+} from "./utils/utils";
 
 const pagesToScrape = await generateUrls(BASE_URL);
 const allArticles: Article[] = [];
 
-for (const page of pagesToScrape) {
-	console.log(`Scraping ${page}`);
-	const rows = await getPageRows(page);
-	const articles: Article[] = Array.from(rows)
-		.map((row) => extractArticlesFromRow(row))
-		.filter((article): article is Article => article !== null);
+const chunks = chunkArray(pagesToScrape, CHUNK_SIZE);
 
-	allArticles.push(...articles);
+for (const chunk of chunks) {
+	const chunkPromises = chunk.map(async (page) => {
+		console.log(`Scraping ${page}`);
+		const rows = await getPageRows(page);
+		return Array.from(rows)
+			.map((row) => extractArticlesFromRow(row))
+			.filter((article): article is Article => article !== null);
+	});
+
+	const results = await Promise.all(chunkPromises);
+	results.forEach((articles) => allArticles.push(...articles));
 }
 
 await Bun.write("articles.json", JSON.stringify(allArticles, null, 2));


### PR DESCRIPTION
💡 **What:**
Optimized `src/getArticles.ts` to scrape pages in parallel instead of sequentially. Used `chunkArray` to batch requests and `Promise.all` to process chunks concurrently, respecting the `CHUNK_SIZE` limit.

🎯 **Why:**
The previous implementation waited for each page to be fully processed before starting the next one, leading to inefficient resource usage and slow total execution time. Parallelizing requests significantly reduces the total time.

📊 **Measured Improvement:**
Benchmark with mocked network latency (100ms per page, 20 pages, CHUNK_SIZE=5):
- Baseline (Sequential): ~2012ms
- Optimized (Concurrent): ~406ms
- Improvement: ~5x speedup

Tests passed. Verified that `chunkArray` and `CHUNK_SIZE` are correctly imported and used.

---
*PR created automatically by Jules for task [1394518798244498683](https://jules.google.com/task/1394518798244498683) started by @nbbaier*