### PR TITLE
⚡ Optimize scraping concurrency using sliding window

### DIFF
--- a/benchmarks/concurrency-comparison.ts
+++ b/benchmarks/concurrency-comparison.ts
@@ -1,0 +1,54 @@
+import { chunkArray, mapWithConcurrency } from "../src/utils/utils";
+
+const ITEM_COUNT = 50;
+const CONCURRENCY = 5;
+const MIN_DELAY = 50;
+const MAX_DELAY = 150;
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const randomDelay = () =>
+  Math.floor(Math.random() * (MAX_DELAY - MIN_DELAY + 1) + MIN_DELAY);
+
+async function runChunked() {
+  const items = Array.from({ length: ITEM_COUNT }, (_, i) => i);
+  const chunks = chunkArray(items, CONCURRENCY);
+
+  const start = performance.now();
+
+  for (const chunk of chunks) {
+    await Promise.all(
+      chunk.map(async () => {
+        await delay(randomDelay());
+      })
+    );
+  }
+
+  return performance.now() - start;
+}
+
+async function runSliding() {
+  const items = Array.from({ length: ITEM_COUNT }, (_, i) => i);
+
+  const start = performance.now();
+
+  await mapWithConcurrency(items, CONCURRENCY, async () => {
+    await delay(randomDelay());
+  });
+
+  return performance.now() - start;
+}
+
+console.log(
+  `Benchmarking ${ITEM_COUNT} items with concurrency ${CONCURRENCY}...`
+);
+console.log(`Task duration: ${MIN_DELAY}-${MAX_DELAY}ms`);
+
+const chunkedTime = await runChunked();
+console.log(`Chunked time: ${chunkedTime.toFixed(2)}ms`);
+
+const slidingTime = await runSliding();
+console.log(`Sliding time: ${slidingTime.toFixed(2)}ms`);
+
+const improvement = ((chunkedTime - slidingTime) / chunkedTime) * 100;
+console.log(`Improvement: ${improvement.toFixed(2)}%`);


### PR DESCRIPTION
💡 **What:**
- Refactored `src/get-articles.ts` to use `mapWithConcurrency` (sliding window) instead of `chunkArray` + `Promise.all`.
- Added a benchmark script `benchmarks/concurrency-comparison.ts` to demonstrate the performance difference.

🎯 **Why:**
- The chunked `Promise.all` approach waits for the slowest task in a chunk to finish before starting the next chunk, leading to idle time.
- A sliding window approach maintains a constant number of concurrent requests, improving overall throughput.
- The task pointed to `src/index.ts`, but that file was already optimized. `src/get-articles.ts` contained the inefficient pattern described.

📊 **Measured Improvement:**
- Benchmark (`benchmarks/concurrency-comparison.ts`) shows ~18% improvement with mock tasks (random 50-150ms delay, concurrency 5, 50 items).
- Real-world improvement depends on network latency variance but should be consistently faster.

---
*PR created automatically by Jules for task [10238659358949263677](https://jules.google.com/task/10238659358949263677) started by @nbbaier*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the concurrency execution pattern for network scraping, which can affect throughput, ordering, and failure behavior under load even though the functional output shape is unchanged.
> 
> **Overview**
> Updates `src/get-articles.ts` to replace chunked `Promise.all` batching with `mapWithConcurrency` (sliding window) so scraping maintains a steady concurrency level and avoids waiting on the slowest request in each batch.
> 
> Adds `benchmarks/concurrency-comparison.ts` to benchmark chunked vs sliding-window concurrency using simulated variable-latency tasks and report the timing difference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 964c40dea9c8d70d454b2962630e205f8ae68ae3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->