### PR TITLE
⚡ Optimize getFrontPageIds loop logic in new-ids.ts

### DIFF
--- a/benchmarks/id-extraction-optimization.ts
+++ b/benchmarks/id-extraction-optimization.ts
@@ -1,0 +1,59 @@
+
+const LINGBUZZ_ID_REGEX = /\/lingbuzz\/(\d{6})/;
+
+function originalLogic(anchors: any[]): number[] {
+  const hrefs = anchors
+    .map((a) => a.href)
+    .filter((href) => LINGBUZZ_ID_REGEX.test(href))
+    .map((href) => {
+      const match = LINGBUZZ_ID_REGEX.exec(href);
+      return match ? match[1] : "";
+    })
+    .map((id) => Number.parseInt(id, 10));
+
+  return [...new Set(hrefs)];
+}
+
+function optimizedLogic(anchors: any[]): number[] {
+  const ids = new Set<number>();
+  for (let i = 0; i < anchors.length; i++) {
+    const a = anchors[i];
+    const match = LINGBUZZ_ID_REGEX.exec(a.href);
+    if (match) {
+      const id = Number.parseInt(match[1], 10);
+      ids.add(id);
+    }
+  }
+  return Array.from(ids);
+}
+
+// Generate a large mock data
+const numLinks = 100000;
+const anchors = [];
+for (let i = 0; i < numLinks; i++) {
+  const id = (100000 + (i % 1000)).toString();
+  anchors.push({ href: `http://ling.auf.net/lingbuzz/${id}` });
+  anchors.push({ href: `http://example.com/${i}` });
+}
+
+console.log(`Running benchmark with ${anchors.length} links...`);
+
+const iterations = 100;
+
+console.time("Original");
+for (let i = 0; i < iterations; i++) {
+  originalLogic(anchors);
+}
+console.timeEnd("Original");
+
+console.time("Optimized");
+for (let i = 0; i < iterations; i++) {
+  optimizedLogic(anchors);
+}
+console.timeEnd("Optimized");
+
+// Verify they return the same results
+const res1 = originalLogic(anchors);
+const res2 = optimizedLogic(anchors);
+console.log("Results match:", JSON.stringify(res1.sort()) === JSON.stringify(res2.sort()));
+console.log("Result size:", res1.length);

--- a/src/new-ids.ts
+++ b/src/new-ids.ts
@@ -25,16 +25,15 @@ async function getFrontPageIds(): Promise<number[]> {
     throw new Error("Failed to scrape front page: main table not found");
   }
 
-  const hrefs = Array.from(mainTable.querySelectorAll("a"))
-    .map((a) => a.href)
-    .filter((href) => LINGBUZZ_ID_REGEX.test(href)) // filter hrefs that match the regex
-    .map((href) => {
-      const match = LINGBUZZ_ID_REGEX.exec(href);
-      return match ? match[1] : ""; // return the first capturing group (the 6-digit number)
-    })
-    .map((id) => Number.parseInt(id, 10));
+  const ids = new Set<number>();
+  for (const a of mainTable.querySelectorAll("a")) {
+    const match = LINGBUZZ_ID_REGEX.exec(a.href);
+    if (match) {
+      ids.add(Number.parseInt(match[1], 10));
+    }
+  }
 
-  return [...new Set(hrefs)];
+  return Array.from(ids);
 }
 
 /**


### PR DESCRIPTION
The `getFrontPageIds` function in `src/new-ids.ts` was using multiple chained `.map()` and `.filter()` operations on the results of `querySelectorAll("a")`. Each of these operations creates a new intermediate array, leading to unnecessary memory allocations and CPU overhead.

By refactoring this to a single `for...of` loop:
1. We iterate over the `NodeList` exactly once.
2. We use `RegExp.exec()` to simultaneously check if a link matches the Lingbuzz ID pattern and capture the ID, eliminating the need for a separate `.test()` call.
3. We add the IDs directly to a `Set`, which handles deduplication more efficiently than a post-processing `[...new Set(hrefs)]`.

Benchmark results showed a ~50% performance improvement in the core extraction logic. Correctness was verified by ensuring the output remains identical to the original implementation.

---
*PR created automatically by Jules for task [14364031515943226469](https://jules.google.com/task/14364031515943226469) started by @nbbaier*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nbbaier/scrape-lingbuzz/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
