### PR TITLE
⚡ perf: cache loadPapers to eliminate redundant parsing of large JSON

### DIFF
--- a/benchmarks/load-papers.ts
+++ b/benchmarks/load-papers.ts
@@ -1,0 +1,17 @@
+import { loadPapers } from "../src/utils/utils";
+
+async function run() {
+  console.time("First load");
+  await loadPapers();
+  console.timeEnd("First load");
+
+  console.time("Second load");
+  await loadPapers();
+  console.timeEnd("Second load");
+
+  console.time("Third load");
+  await loadPapers();
+  console.timeEnd("Third load");
+}
+
+run();

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import { file, write } from "bun";
-import type { JSDOM } from "jsdom";
 import {
   BASE_URL,
   PAGINATION_FIRST_START,
@@ -33,7 +32,9 @@ export async function getPaperCount(BASE_URL: string): Promise<number> {
   const html = await res.text();
 
   // Use regex to find the paper count element: <center><b><a ...>...</a></b></center>
-  const match = html.match(/<center>\s*<b>\s*<a[^>]*>(.*?)<\/a>\s*<\/b>\s*<\/center>/is);
+  const match = html.match(
+    /<center>\s*<b>\s*<a[^>]*>(.*?)<\/a>\s*<\/b>\s*<\/center>/is
+  );
 
   if (!match) {
     logger.error("Paper count element not found");
@@ -143,23 +144,38 @@ export const extractArticlesFromRow = (row: any): Article | null => {
   };
 };
 
+let cachedPapers: Paper[] | null = null;
+let cachedPapersFilePath: string | null = null;
+
 /**
  * Loads previously scraped papers data from a JSON file.
  *
  * @param papersFilePath - The path to the papers JSON file. Defaults to PAPERS_FILE_PATH.
+ * @param forceReload - Whether to bypass the cache and reload the file. Defaults to false.
  * @returns A promise that resolves to an array of Paper objects.
  * @throws If there is an error loading the papers data.
  */
 export async function loadPapers(
-  papersFilePath = PAPERS_FILE_PATH
+  papersFilePath = PAPERS_FILE_PATH,
+  forceReload = false
 ): Promise<Paper[]> {
+  if (
+    !forceReload &&
+    cachedPapers !== null &&
+    cachedPapersFilePath === papersFilePath
+  ) {
+    return cachedPapers;
+  }
+
   try {
     if (!fs.existsSync(papersFilePath)) {
       logger.info(`Creating ${papersFilePath}`);
       await write(papersFilePath, JSON.stringify([]));
     }
     const papersFile = file(papersFilePath);
-    return JSON.parse(await papersFile.text());
+    cachedPapers = JSON.parse(await papersFile.text());
+    cachedPapersFilePath = papersFilePath;
+    return cachedPapers as Paper[];
   } catch (error) {
     logger.error("Failed to load papers:", error);
     throw new Error("Error loading papers data");

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -175,7 +175,7 @@ export async function loadPapers(
     const papersFile = file(papersFilePath);
     cachedPapers = JSON.parse(await papersFile.text());
     cachedPapersFilePath = papersFilePath;
-    return cachedPapers as Paper[];
+    return [...cachedPapers] as Paper[];
   } catch (error) {
     logger.error("Failed to load papers:", error);
     throw new Error("Error loading papers data");

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -250,6 +250,9 @@ export async function writePapersFile(
 
   await writeFile(tempPath, JSON.stringify(sanitizedPapers), "utf8");
   await rename(tempPath, papersFilePath);
+
+  cachedPapers = sanitizedPapers;
+  cachedPapersFilePath = papersFilePath;
 }
 
 /**

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -164,7 +164,7 @@ export async function loadPapers(
     cachedPapers !== null &&
     cachedPapersFilePath === papersFilePath
   ) {
-    return cachedPapers;
+    return [...cachedPapers];
   }
 
   try {


### PR DESCRIPTION
💡 **What:** Added in-memory caching to the `loadPapers()` function in `src/utils/utils.ts` using module-level variables. If the function is called again with the same `papersFilePath`, it will return the cached data instead of reading from the disk and re-parsing the large `papers.json` file. A `forceReload` parameter was also added for cases where the fresh file needs to be read.
🎯 **Why:** The codebase was previously calling `loadPapers()` multiple times in `src/index.ts` during a single execution (e.g., in `newIds()`, then `const currentPapers = await loadPapers();` before scraping, and again inside `scrapePapers()`). Because `papers.json` can be quite large (e.g., 16MB), reading it and calling `JSON.parse()` multiple times per run consumes a significant amount of CPU and delays the execution.
📊 **Measured Improvement:** Created a benchmark `benchmarks/load-papers.ts` to measure `loadPapers` executions.
Before/Without Cache: Each call takes ~830ms-900ms.
After/With Cache:
- First load: ~830.33ms
- Second load: ~0.06ms
- Third load: ~0.04ms
This represents nearly a 100% speedup on subsequent loads, saving around ~1.6 seconds of total execution time in the default scraping flow where the file is loaded 3 times.

---
*PR created automatically by Jules for task [12992264872333864647](https://jules.google.com/task/12992264872333864647) started by @nbbaier*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nbbaier/scrape-lingbuzz/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->