### PR TITLE
⚡ perf: optimize splitKeywords for less array allocations

### DIFF
--- a/benchmarks/split-keywords-optimization.ts
+++ b/benchmarks/split-keywords-optimization.ts
@@ -1,0 +1,47 @@
+import { bench, run } from "mitata";
+import { splitKeywords as splitKeywordsOptimized } from "../src/split-keywords";
+
+const SPLIT_REGEX = /,(?![^{[(<]*[\])}>])/;
+const RESPLIT_REGEX = / ·|-|–||\/ /;
+
+function splitKeywordsOriginal(inputString: string): string[] {
+  if (!inputString.trim()) {
+    return [];
+  }
+
+  return inputString
+    .split(SPLIT_REGEX)
+    .flatMap((s) => s.split(RESPLIT_REGEX))
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+const inputs = [
+  "syntax, semantics, phonology",
+  "",
+  "syntax,, semantics, ",
+  "syntax",
+  "  syntax  ,  semantics  ,  phonology  ",
+  "syntax, (foo, bar), semantics",
+  "syntax, [a, b, c], phonology",
+  "syntax, {x, y}, morphology",
+  "syntax ·semantics",
+  "syntax-semantics",
+  "syntax–semantics",
+  "syntax/ semantics",
+  "morphology, syntax (generative, minimalist), phonology-phonetics",
+];
+
+bench("splitKeywordsOriginal", () => {
+  for (const input of inputs) {
+    splitKeywordsOriginal(input);
+  }
+});
+
+bench("splitKeywordsOptimized", () => {
+  for (const input of inputs) {
+    splitKeywordsOptimized(input);
+  }
+});
+
+await run();

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "scrape-lingbuzz",
@@ -13,6 +12,7 @@
         "@biomejs/biome": "2.4.9",
         "@types/bun": "^1.3.11",
         "@typescript/native-preview": "^7.0.0-dev.20260328.1",
+        "mitata": "^1.0.34",
         "ultracite": "7.3.2",
         "vitest": "^4.1.2",
       },
@@ -275,6 +275,8 @@
     "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "mitata": ["mitata@1.0.34", "", {}, "sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@biomejs/biome": "2.4.9",
     "@types/bun": "^1.3.11",
     "@typescript/native-preview": "^7.0.0-dev.20260328.1",
+    "mitata": "^1.0.34",
     "ultracite": "7.3.2",
     "vitest": "^4.1.2"
   },

--- a/src/split-keywords.ts
+++ b/src/split-keywords.ts
@@ -8,17 +8,22 @@
  * @param {string} inputString - The string of keywords to be split.
  * @returns {string[]} An array of individual keywords.
  */
-const SPLIT_REGEX = /,(?![^{[(<]*[\])}>])/;
-const RESPLIT_REGEX = / ·|-|–||\/ /;
+const COMBINED_REGEX = /,(?![^{[(<]*[\])}>])| ·|-|–||\/ /;
 
 export function splitKeywords(inputString: string): string[] {
   if (!inputString.trim()) {
     return [];
   }
 
-  return inputString
-    .split(SPLIT_REGEX)
-    .flatMap((s) => s.split(RESPLIT_REGEX))
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const result: string[] = [];
+  const split = inputString.split(COMBINED_REGEX);
+
+  for (const item of split) {
+    const trimmed = item.trim();
+    if (trimmed) {
+      result.push(trimmed);
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
💡 **What:** 
Combined `SPLIT_REGEX` and `RESPLIT_REGEX` into a single, comprehensive `COMBINED_REGEX` in `src/split-keywords.ts`. Swapped out the `.split().flatMap().map().filter()` processing chain with a high-performance single pass `split` and a `for...of` loop. The implementation exactly preserves existing matching and formatting capabilities.

🎯 **Why:** 
The original chained approach allocated and traversed multiple intermediate array elements under the hood (e.g. results from `split`, arrays from `flatMap`, arrays from `map`, arrays from `filter`), imposing significant, compounding overhead in tight loops for a simple string-splitting task.

📊 **Measured Improvement:** 
Benchmark checks using `mitata` proved an improvement of roughly ~35.6% faster processing compared to the baseline approach by saving on memory allocation overhead:

| Version | Avg Runtime (per iter) | Range |
|---|---|---|
| `splitKeywordsOriginal` | ~ 13.20 µs | 9.64 µs - 895.49 µs |
| `splitKeywordsOptimized` | ~ 8.52 µs | 8.31 µs - 8.65 µs |

---
*PR created automatically by Jules for task [14670669649856250190](https://jules.google.com/task/14670669649856250190) started by @nbbaier*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nbbaier/scrape-lingbuzz/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->