### PR TITLE
test: type console mocks so root typecheck passes

### DIFF
--- a/src/tests/logger.test.ts
+++ b/src/tests/logger.test.ts
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { logger } from "../utils/logger";
 
@@ -6,14 +7,14 @@ const ISO_TIMESTAMP_REGEX = /\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]/;
 describe("logger", () => {
   let originalLog: typeof console.log;
   let originalError: typeof console.error;
-  let mockLog: ReturnType<typeof vi.fn>;
-  let mockError: ReturnType<typeof vi.fn>;
+  let mockLog: Mock<typeof console.log>;
+  let mockError: Mock<typeof console.error>;
 
   beforeEach(() => {
     originalLog = console.log;
     originalError = console.error;
-    mockLog = vi.fn();
-    mockError = vi.fn();
+    mockLog = vi.fn<typeof console.log>();
+    mockError = vi.fn<typeof console.error>();
     console.log = mockLog;
     console.error = mockError;
   });


### PR DESCRIPTION
## Summary
- Fixes root `bun run typecheck` failure on `refactor/monorepo` at `a4b6f2b`: `mockLog`/`mockError` in `src/tests/logger.test.ts` were typed as `ReturnType<typeof vi.fn>`, which no longer assigns to `typeof console.log`/`console.error` after the vitest bump in `097c0dd`.
- Types the mocks as `Mock<typeof console.log>` / `Mock<typeof console.error>` (via `vi.fn<typeof console.log>()` etc.), avoiding casts, so the assignments typecheck directly.
- No runtime/assertion changes — all 10 logger tests still pass unmodified.

Closes plan 001a (GitHub issue #62); unblocks #46.

## Test plan
- [x] `bun run typecheck` exits 0
- [x] `bun run test src/tests/logger.test.ts` — 10/10 pass
- [x] `bun run check` exits 0
- [x] `git diff --stat` against `refactor/monorepo` shows only `src/tests/logger.test.ts`

Note: `bun run test` (full suite) has 2 pre-existing failing suites (`utils.test.ts`, `new-ids.test.ts`, "Cannot find package 'bun'") unrelated to this change — reproduced identically on `refactor/monorepo` HEAD before this fix, and out of this plan's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)