### PR TITLE
fix: repair typecheck wiring and legacy bun imports for CI baseline

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250205.0",
+    "@types/node": "^26.1.0",
     "wrangler": "^4.0.0"
   }
 }

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -44,7 +44,10 @@ admin.post("/embed", async (c) => {
 
       const embeddingData =
         "data" in embeddingResponse ? embeddingResponse.data : undefined;
-      if (!embeddingData) {
+      if (
+        !Array.isArray(embeddingData) ||
+        embeddingData.length !== batch.length
+      ) {
         throw new Error("Unexpected AI response shape");
       }
 

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -42,9 +42,15 @@ admin.post("/embed", async (c) => {
         { text: texts }
       );
 
+      const embeddingData =
+        "data" in embeddingResponse ? embeddingResponse.data : undefined;
+      if (!embeddingData) {
+        throw new Error("Unexpected AI response shape");
+      }
+
       const vectors = batch.map((p, idx) => ({
         id: p.lingbuzzId,
-        values: embeddingResponse.data[idx],
+        values: embeddingData[idx],
         metadata: {
           lingbuzzId: p.lingbuzzId,
           title: p.paperTitle,

--- a/apps/api/src/routes/semantic.ts
+++ b/apps/api/src/routes/semantic.ts
@@ -32,7 +32,7 @@ semantic.get("/", async (c) => {
     });
     const embeddingData =
       "data" in embeddingResponse ? embeddingResponse.data : undefined;
-    if (!embeddingData) {
+    if (!Array.isArray(embeddingData) || embeddingData.length < 1) {
       throw new Error("Unexpected AI response shape");
     }
     const vector = embeddingData[0];

--- a/apps/api/src/routes/semantic.ts
+++ b/apps/api/src/routes/semantic.ts
@@ -30,7 +30,12 @@ semantic.get("/", async (c) => {
     const embeddingResponse = await c.env.AI.run("@cf/baai/bge-base-en-v1.5", {
       text: [query],
     });
-    const vector = embeddingResponse.data[0];
+    const embeddingData =
+      "data" in embeddingResponse ? embeddingResponse.data : undefined;
+    if (!embeddingData) {
+      throw new Error("Unexpected AI response shape");
+    }
+    const vector = embeddingData[0];
 
     const vectorResults = await c.env.VECTORIZE.query(vector, {
       topK: limit,

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types", "node"]
+  },
   "include": ["src/**/*.ts"]
 }

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -1,6 +1,7 @@
 name = "lingbuzz-api"
 main = "src/index.ts"
 compatibility_date = "2025-02-07"
+compatibility_flags = ["nodejs_compat"]
 
 # Turso credentials should be set via `wrangler secret put`:
 # wrangler secret put TURSO_DATABASE_URL

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250205.0",
+        "@types/node": "^26.1.0",
         "wrangler": "^4.0.0",
       },
     },
@@ -338,7 +339,7 @@
 
     "@types/jsdom": ["@types/jsdom@27.0.0", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0" } }, "sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw=="],
 
-    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
 
@@ -594,7 +595,7 @@
 
     "undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
@@ -631,6 +632,12 @@
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "@types/jsdom/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@types/ws/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "bun-types/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "drizzle-kit/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -683,6 +690,12 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@types/jsdom/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "drizzle-kit/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["bun"]
+  },
   "include": ["src/**/*.ts", "drizzle.config.ts"]
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import { file, write } from "bun";
 import { JSDOM } from "jsdom";
 import {
   BASE_URL,
@@ -156,10 +155,9 @@ export async function loadPapers(
   try {
     if (!fs.existsSync(papersFilePath)) {
       logger.info(`Creating ${papersFilePath}`);
-      await write(papersFilePath, JSON.stringify([]));
+      await fs.promises.writeFile(papersFilePath, JSON.stringify([]));
     }
-    const papersFile = file(papersFilePath);
-    return JSON.parse(await papersFile.text());
+    return JSON.parse(await fs.promises.readFile(papersFilePath, "utf-8"));
   } catch (error) {
     logger.error("Failed to load papers:", error);
     throw new Error("Error loading papers data");


### PR DESCRIPTION
Implements plan 001b (#64): repairs the three baseline verification failures blocking the CI workflow plan (#46).

## Changes

- **`packages/db/tsconfig.json`**: add `"types": ["bun"]` so `process.env` resolves (fixes `@lingbuzz/db` typecheck, was exit 2 with 4 `Cannot find name 'process'` errors).
- **`apps/api/tsconfig.json` + `apps/api/package.json`**: add `@types/node` devDependency and `"types": ["@cloudflare/workers-types", "node"]` so `Ai`, `VectorizeIndex`, and `process` resolve (fixes `@lingbuzz/api` typecheck).
- **`apps/api/src/routes/admin.ts`, `apps/api/src/routes/semantic.ts`**: narrow the `AI.run("@cf/baai/bge-base-en-v1.5", ...)` response with a `"data" in ...` guard that throws `Unexpected AI response shape` on the async-queue union member (the two real type errors surfaced by wiring workers-types).
- **`src/utils/utils.ts`**: remove `import { file, write } from "bun"` and use `fs.promises.writeFile`/`readFile` in `loadPapers` (fixes root vitest collection failure in `new-ids.test.ts` and `utils.test.ts`; 7 files / 67 tests now pass).
- **`bun.lock`**: regenerated by `bun add -d @types/node` in `apps/api` (top-level `@types/node` resolution moved 25.5.0 → 26.1.0, with 25.5.0 pinned for existing consumers).

## Verification (all exit 0 from fresh `bun install`)

`bun run check`; root/db/scraper/api typecheck; root (7 files, 67 tests), db, scraper, api test suites.

Unblocks #46. Refs #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)