### PR TITLE
ci: add test/lint/typecheck workflow for all workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - refactor/monorepo
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Set up bun
+        uses: oven-sh/setup-bun@v2
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+      - name: Install dependencies
+        run: bun install
+      - name: Lint
+        run: bun run check
+      - name: Typecheck (root/legacy)
+        run: bun run typecheck
+      - name: Typecheck db
+        run: bun --filter @lingbuzz/db typecheck
+      - name: Typecheck scraper
+        run: bun --filter @lingbuzz/scraper typecheck
+      - name: Typecheck api
+        run: bun --filter @lingbuzz/api typecheck
+      - name: Tests (legacy root src/)
+        run: bun run test
+      - name: Tests db
+        run: bun --filter @lingbuzz/db test
+      - name: Tests scraper
+        run: bun --filter @lingbuzz/scraper test
+      - name: Tests api
+        run: bun --filter @lingbuzz/api test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
       - name: Lint
         run: bun run check
       - name: Typecheck (root/legacy)


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml`, the repo's first CI quality gate: runs lint, typecheck, and tests across all workspaces (root/legacy, `@lingbuzz/db`, `@lingbuzz/scraper`, `@lingbuzz/api`) on push to `main`/`refactor/monorepo` and on every PR.
- Does not touch the existing `.github/workflows/scrape.yml` or `jq.yml`.

Closes #46

## Test plan
- [x] `bun install` — exit 0
- [x] `bun run check` — exit 0
- [x] `bun run typecheck` — exit 0
- [x] `bun --filter @lingbuzz/db typecheck` — exit 0
- [x] `bun --filter @lingbuzz/scraper typecheck` — exit 0
- [x] `bun --filter @lingbuzz/api typecheck` — exit 0
- [x] `bun run test` — 67 passed (7 files)
- [x] `bun --filter @lingbuzz/db test` — 5 passed
- [x] `bun --filter @lingbuzz/scraper test` — 80 passed (8 files)
- [x] `bun --filter @lingbuzz/api test` — 16 passed (3 files)
- [ ] CI run green on this PR (`gh pr checks`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)