### PR TITLE
fix: restore resilient front-page table detection and repair .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
+# Dependencies
+node_modules/
+
 # Build and test output
 coverage/
 dist/
 *.tsbuildinfo
 
 # Local environment overrides
+.env
 .env.local
 .env.*.local
 

--- a/packages/scraper/src/listing.ts
+++ b/packages/scraper/src/listing.ts
@@ -112,8 +112,15 @@ export async function fetchListingPage(url: string): Promise<ListingRow[]> {
   const document = new JSDOM(html).window.document;
 
   const tables = document.body.querySelectorAll("table");
-  const mainTable =
-    tables.length > 2 ? tables[2].querySelector("td > table") : null;
+
+  let mainTable: Element | null = null;
+  for (const table of tables) {
+    const nested = table.querySelector("td > table");
+    if (nested?.querySelector(`a[href*="/lingbuzz/"]`)) {
+      mainTable = nested;
+      break;
+    }
+  }
 
   if (!mainTable) {
     logger.warn(`Main table not found on listing page: ${url}`);

--- a/packages/scraper/tests/listing.test.ts
+++ b/packages/scraper/tests/listing.test.ts
@@ -1,6 +1,6 @@
 import { JSDOM } from "jsdom";
-import { describe, expect, test } from "vitest";
-import { parseListingRow } from "../src/listing";
+import { describe, expect, test, vi } from "vitest";
+import { fetchListingPage, parseListingRow } from "../src/listing";
 
 function createRow(html: string): HTMLTableRowElement {
   const dom = new JSDOM(`<table><tbody><tr>${html}</tr></tbody></table>`);
@@ -105,5 +105,56 @@ describe("parseListingRow", () => {
     const result = parseListingRow(row);
     expect(result).not.toBeNull();
     expect(result?.downloadUrl).toBe("");
+  });
+});
+
+describe("fetchListingPage", () => {
+  test("parses rows when an intermittent banner table precedes the content table", async () => {
+    const mockHtml = `
+      <html>
+      <body>
+        <table><tr><td>announcement</td></tr></table>
+        <table></table>
+        <table></table>
+        <table>
+          <tr>
+            <td>
+              <table>
+                <tr>
+                  <td><a href="/_person/jdoe">Doe, John</a></td>
+                  <td>new</td>
+                  <td><a href="/lingbuzz/007001/current.pdf?_s=abc">pdf</a></td>
+                  <td><a href="/lingbuzz/007001">A New Paper</a></td>
+                </tr>
+                <tr>
+                  <td><a href="/_person/asmith">Smith, Alice</a></td>
+                  <td>2026-01</td>
+                  <td><a href="/lingbuzz/006500/current.pdf">pdf</a></td>
+                  <td><a href="/lingbuzz/006500">An Updated Paper</a></td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </body>
+      </html>
+    `;
+
+    const retryModule = await import("../src/utils/retry");
+    const fetchSpy = vi
+      .spyOn(retryModule, "fetchWithRetry")
+      .mockResolvedValue(new Response(mockHtml));
+
+    const rows = await fetchListingPage(
+      "https://ling.auf.net/lingbuzz/_listing?start=1"
+    );
+
+    expect(rows.length).toBe(2);
+    expect(rows[0].paperId).toBe("007001");
+    expect(rows[0].title).toBe("A New Paper");
+    expect(rows[1].paperId).toBe("006500");
+    expect(rows[1].status).toBe("2026-01");
+
+    fetchSpy.mockRestore();
   });
 });

--- a/src/new-ids.ts
+++ b/src/new-ids.ts
@@ -19,13 +19,14 @@ async function getFrontPageIds(): Promise<number[]> {
 
   const tables = document.body.querySelectorAll("table");
 
-  for (const table of Array.from(tables).slice(0, 2)) {
-    console.log("\n");
-    console.log(table.innerHTML);
+  let mainTable: Element | null = null;
+  for (const table of tables) {
+    const nested = table.querySelector("td > table");
+    if (nested?.querySelector(`a[href*="/lingbuzz/"]`)) {
+      mainTable = nested;
+      break;
+    }
   }
-
-  const mainTable =
-    tables.length > 2 ? tables[3].querySelector("td > table") : null;
 
   if (!mainTable) {
     throw new Error("Failed to scrape front page: main table not found");

--- a/src/tests/new-ids.test.ts
+++ b/src/tests/new-ids.test.ts
@@ -22,6 +22,28 @@ const mockHtml = `
 </html>
 `;
 
+// Mock data with an intermittent banner table prepended before the content table
+const mockHtmlWithBanner = `
+<html>
+<body>
+  <table><tr><td>announcement</td></tr></table>
+  <table></table>
+  <table></table>
+  <table>
+    <tr>
+      <td>
+        <table>
+          <tr><td><a href="http://ling.auf.net/lingbuzz/123456">Link 1</a></td></tr>
+          <tr><td><a href="http://ling.auf.net/lingbuzz/123456">Link 1 Dup</a></td></tr>
+          <tr><td><a href="http://ling.auf.net/lingbuzz/654321">Link 2</a></td></tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+`;
+
 describe("newIds", () => {
   test("should return deduplicated IDs", async () => {
     // Mock fetchWithRetry to return our HTML
@@ -54,6 +76,41 @@ describe("newIds", () => {
     // The order depends on the implementation, but we expect 123456 and 654321
     // Since Set preserves insertion order, and filter does too:
     // 123456 appears first, then 654321.
+    expect(ids).toEqual([123_456, 654_321]);
+    expect(ids.length).toBe(2);
+
+    fetchSpy.mockRestore();
+    loadPapersSpy.mockRestore();
+  });
+
+  test("should return deduplicated IDs when an intermittent banner table is present", async () => {
+    // Mock fetchWithRetry to return HTML with a banner table before the content table
+    const retryModule = await import("../utils/retry");
+    const fetchSpy = vi
+      .spyOn(retryModule, "fetchWithRetry")
+      .mockResolvedValue(new Response(mockHtmlWithBanner));
+
+    // Mock loadPapers to return a dummy paper so newIds logic proceeds
+    const utilsModule = await import("../utils/utils");
+    const loadPapersSpy = vi
+      .spyOn(utilsModule, "loadPapers")
+      .mockResolvedValue([
+        {
+          id: "000000",
+          title: "Dummy",
+          authors: [],
+          date: "",
+          published_in: "",
+          keywords: [],
+          keywords_raw: "",
+          abstract: "",
+          link: "",
+          downloads: 0,
+        },
+      ]);
+
+    const ids = await newIds();
+
     expect(ids).toEqual([123_456, 654_321]);
     expect(ids.length).toBe(2);
 


### PR DESCRIPTION
## Summary

- Restore index-free main-table detection (scan tables, pick the nested one containing `/lingbuzz/` links) in both the legacy scraper (`src/new-ids.ts`) and the new scraper (`packages/scraper/src/listing.ts`). The hardcoded `tables[3]`/`tables[2]` lookups broke whenever lingbuzz's intermittent banner table appeared or disappeared; `tables[3]` (from e12a878) is why CI on main is red.
- Remove leftover debug `console.log` statements from `src/new-ids.ts`.
- Add banner-present regression tests for both scrapers (the banner-absent case is covered by the existing test).
- Repair `.gitignore`: re-add `node_modules/` (the cron's commit step was trying to commit the dependency tree) and bare `.env`.

Implements Plan 017 (supports #45).

## Test plan

- [x] `bun run check`, root + scraper typecheck: exit 0
- [x] `bun run test` (68/68) and `bun --filter @lingbuzz/scraper test` (81/81): green, including new banner-regression tests
- [x] Live smoke test against https://ling.auf.net/lingbuzz: detection finds the main table, 30 unique IDs
- [x] `git check-ignore` confirms `node_modules` and `.env` ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)