### PR TITLE
feat: record sync runs and expose GET /sync/latest

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import authors from "./routes/authors";
 import papers from "./routes/papers";
 import search from "./routes/search";
 import semantic from "./routes/semantic";
+import sync from "./routes/sync";
 import type { Variables } from "./types";
 
 interface Bindings {
@@ -33,6 +34,7 @@ app.route("/authors", authors);
 app.route("/search/semantic", semantic);
 app.route("/search", search);
 app.route("/admin", admin);
+app.route("/sync", sync);
 
 app.get("/", (c) => {
   return c.json({ message: "lingbuzz API" });

--- a/apps/api/src/routes/sync.ts
+++ b/apps/api/src/routes/sync.ts
@@ -1,0 +1,26 @@
+import { selectLatestSyncRun } from "@lingbuzz/db/queries/sync";
+import { Hono } from "hono";
+import type { Variables } from "../types";
+
+const sync = new Hono<{ Variables: Variables }>();
+
+sync.get("/latest", async (c) => {
+  const latest = await selectLatestSyncRun(c.get("db"));
+
+  if (!latest) {
+    return c.json({ error: "No sync runs recorded" }, 404);
+  }
+
+  return c.json({
+    data: {
+      runner: latest.runner,
+      startedAt: latest.startedAt,
+      finishedAt: latest.finishedAt,
+      papersNew: latest.papersNew,
+      papersUpdated: latest.papersUpdated,
+      success: latest.success,
+    },
+  });
+});
+
+export default sync;

--- a/apps/api/tests/sync.test.ts
+++ b/apps/api/tests/sync.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@lingbuzz/db/queries/sync", () => ({
+  selectLatestSyncRun: vi.fn(),
+}));
+
+import type { Db } from "@lingbuzz/db";
+import { selectLatestSyncRun } from "@lingbuzz/db/queries/sync";
+import { Hono } from "hono";
+import syncRoute from "../src/routes/sync";
+
+const mockSelectLatestSyncRun = vi.mocked(selectLatestSyncRun);
+
+const mockDb = {} as Db;
+
+function createApp() {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("db", mockDb);
+    await next();
+  });
+  app.route("/", syncRoute);
+  return app;
+}
+
+const app = createApp();
+
+describe("GET /latest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns the latest sync run projection", async () => {
+    const startedAt = new Date("2026-07-04T10:00:00.000Z");
+    const finishedAt = new Date("2026-07-04T10:05:00.000Z");
+    mockSelectLatestSyncRun.mockResolvedValueOnce({
+      syncRunId: 3,
+      runner: "gh-actions",
+      startedAt,
+      finishedAt,
+      papersSeen: 42,
+      papersNew: 7,
+      papersUpdated: 3,
+      papersFailed: 1,
+      success: true,
+      errorMessage: null,
+      rowCreatedAt: startedAt,
+      rowUpdatedAt: finishedAt,
+    });
+
+    const response = await app.request("http://localhost/latest");
+
+    expect(response.status).toBe(200);
+    expect(mockSelectLatestSyncRun).toHaveBeenCalledWith(mockDb);
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        runner: "gh-actions",
+        startedAt: startedAt.toISOString(),
+        finishedAt: finishedAt.toISOString(),
+        papersNew: 7,
+        papersUpdated: 3,
+        success: true,
+      },
+    });
+  });
+
+  test("returns 404 when no sync runs are recorded", async () => {
+    mockSelectLatestSyncRun.mockResolvedValueOnce(undefined);
+
+    const response = await app.request("http://localhost/latest");
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "No sync runs recorded",
+    });
+  });
+});

--- a/packages/db/migrations/20260712002418_crazy_ink.sql
+++ b/packages/db/migrations/20260712002418_crazy_ink.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `sync_runs` (
+	`sync_run_id` integer PRIMARY KEY NOT NULL,
+	`runner` text NOT NULL,
+	`started_at` integer NOT NULL,
+	`finished_at` integer,
+	`papers_seen` integer DEFAULT 0 NOT NULL,
+	`papers_new` integer DEFAULT 0 NOT NULL,
+	`papers_updated` integer DEFAULT 0 NOT NULL,
+	`papers_failed` integer DEFAULT 0 NOT NULL,
+	`success` integer DEFAULT false NOT NULL,
+	`error_message` text,
+	`row_created_at` integer,
+	`row_updated_at` integer
+);

--- a/packages/db/migrations/meta/20260712002418_snapshot.json
+++ b/packages/db/migrations/meta/20260712002418_snapshot.json
@@ -1,0 +1,557 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "647ad21a-af87-4bac-ab7d-d733b052ee42",
+  "prevId": "8f5666a5-493e-4358-b8a4-eb363e21b278",
+  "tables": {
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "affiliation": {
+          "name": "affiliation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "row_created_at": {
+          "name": "row_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "row_updated_at": {
+          "name": "row_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "authors_username_unique": {
+          "name": "authors_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "authors_names": {
+          "name": "authors_names",
+          "columns": [
+            "last_name",
+            "first_name"
+          ],
+          "isUnique": false
+        },
+        "authors_email": {
+          "name": "authors_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "authors_to_papers": {
+      "name": "authors_to_papers",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_position": {
+          "name": "author_position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_created_at": {
+          "name": "row_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "row_updated_at": {
+          "name": "row_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authors_to_papers_author_id_authors_author_id_fk": {
+          "name": "authors_to_papers_author_id_authors_author_id_fk",
+          "tableFrom": "authors_to_papers",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "author_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "authors_to_papers_paper_id_papers_paper_id_fk": {
+          "name": "authors_to_papers_paper_id_papers_paper_id_fk",
+          "tableFrom": "authors_to_papers",
+          "tableTo": "papers",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "paper_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "authors_to_papers_author_id_paper_id_pk": {
+          "columns": [
+            "author_id",
+            "paper_id"
+          ],
+          "name": "authors_to_papers_author_id_paper_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keywords": {
+      "name": "keywords",
+      "columns": {
+        "keyword_id": {
+          "name": "keyword_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_created_at": {
+          "name": "row_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "row_updated_at": {
+          "name": "row_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "keywords_keyword_unique": {
+          "name": "keywords_keyword_unique",
+          "columns": [
+            "keyword"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keywords_to_papers": {
+      "name": "keywords_to_papers",
+      "columns": {
+        "keyword_id": {
+          "name": "keyword_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paper_id": {
+          "name": "paper_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_created_at": {
+          "name": "row_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "row_updated_at": {
+          "name": "row_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "keywords_to_papers_keyword_id_keywords_keyword_id_fk": {
+          "name": "keywords_to_papers_keyword_id_keywords_keyword_id_fk",
+          "tableFrom": "keywords_to_papers",
+          "tableTo": "keywords",
+          "columnsFrom": [
+            "keyword_id"
+          ],
+          "columnsTo": [
+            "keyword_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "keywords_to_papers_paper_id_papers_paper_id_fk": {
+          "name": "keywords_to_papers_paper_id_papers_paper_id_fk",
+          "tableFrom": "keywords_to_papers",
+          "tableTo": "papers",
+          "columnsFrom": [
+            "paper_id"
+          ],
+          "columnsTo": [
+            "paper_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "keywords_to_papers_keyword_id_paper_id_pk": {
+          "columns": [
+            "keyword_id",
+            "paper_id"
+          ],
+          "name": "keywords_to_papers_keyword_id_paper_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "papers": {
+      "name": "papers",
+      "columns": {
+        "paper_id": {
+          "name": "paper_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lingbuzz_id": {
+          "name": "lingbuzz_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paper_title": {
+          "name": "paper_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_in": {
+          "name": "published_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paper_year": {
+          "name": "paper_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "paper_month": {
+          "name": "paper_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "keywords_raw": {
+          "name": "keywords_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "abstract": {
+          "name": "abstract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paper_reference": {
+          "name": "paper_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_url": {
+          "name": "download_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paper_url": {
+          "name": "paper_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedded_at": {
+          "name": "embedded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "row_created_at": {
+          "name": "row_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "row_updated_at": {
+          "name": "row_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "papers_lingbuzzId_unique": {
+          "name": "papers_lingbuzzId_unique",
+          "columns": [
+            "lingbuzz_id"
+          ],
+          "isUnique": true
+        },
+        "papers_year": {
+          "name": "papers_year",
+          "columns": [
+            "paper_year"
+          ],
+          "isUnique": false
+        },
+        "papers_month": {
+          "name": "papers_month",
+          "columns": [
+            "paper_month"
+          ],
+          "isUnique": false
+        },
+        "papers_date": {
+          "name": "papers_date",
+          "columns": [
+            "paper_year",
+            "paper_month"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_runs": {
+      "name": "sync_runs",
+      "columns": {
+        "sync_run_id": {
+          "name": "sync_run_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "papers_seen": {
+          "name": "papers_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "papers_new": {
+          "name": "papers_new",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "papers_updated": {
+          "name": "papers_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "papers_failed": {
+          "name": "papers_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "row_created_at": {
+          "name": "row_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "row_updated_at": {
+          "name": "row_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/migrations/meta/_journal.json
+++ b/packages/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1771620243242,
       "tag": "20260220204403_elite_nicolaos",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1783815858062,
+      "tag": "20260712002418_crazy_ink",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,6 +11,7 @@
     "./queries/select": "./src/queries/select.ts",
     "./queries/insert": "./src/queries/insert.ts",
     "./queries/search": "./src/queries/search.ts",
+    "./queries/sync": "./src/queries/sync.ts",
     "./queries/utils": "./src/queries/query-utils.ts",
     "./trigger": "./src/trigger.ts"
   },

--- a/packages/db/src/queries/sync.ts
+++ b/packages/db/src/queries/sync.ts
@@ -1,0 +1,59 @@
+import { desc, eq } from "drizzle-orm";
+import type { Db } from "../client";
+import { syncRuns } from "../schema";
+
+export type SyncRun = typeof syncRuns.$inferSelect;
+
+export interface SyncRunStart {
+  runner: string;
+  startedAt: Date;
+}
+
+export interface SyncRunFinish {
+  finishedAt: Date;
+  papersSeen: number;
+  papersNew: number;
+  papersUpdated: number;
+  papersFailed: number;
+  success: boolean;
+  errorMessage?: string;
+}
+
+/**
+ * Inserts a row marking the start of a Sync run and returns its id.
+ */
+export async function insertSyncRunStart(
+  db: Db,
+  { runner, startedAt }: SyncRunStart
+): Promise<number> {
+  const [row] = await db
+    .insert(syncRuns)
+    .values({ runner, startedAt })
+    .returning({ syncRunId: syncRuns.syncRunId });
+  return row.syncRunId;
+}
+
+/**
+ * Fills in the outcome columns of a previously started Sync run.
+ */
+export async function finishSyncRun(
+  db: Db,
+  id: number,
+  finish: SyncRunFinish
+): Promise<void> {
+  await db.update(syncRuns).set(finish).where(eq(syncRuns.syncRunId, id));
+}
+
+/**
+ * Returns the most recent Sync run by `startedAt`, or undefined if none exist.
+ */
+export async function selectLatestSyncRun(
+  db: Db
+): Promise<SyncRun | undefined> {
+  const [row] = await db
+    .select()
+    .from(syncRuns)
+    .orderBy(desc(syncRuns.startedAt))
+    .limit(1);
+  return row;
+}

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -119,6 +119,20 @@ export const keywordsToPapers = sqliteTable(
   (t) => [primaryKey({ columns: [t.keywordId, t.paperId] })]
 );
 
+export const syncRuns = sqliteTable("sync_runs", (t) => ({
+  syncRunId: t.integer().primaryKey(),
+  runner: t.text().notNull(),
+  startedAt: t.integer({ mode: "timestamp" }).notNull(),
+  finishedAt: t.integer({ mode: "timestamp" }),
+  papersSeen: t.integer().notNull().default(0),
+  papersNew: t.integer().notNull().default(0),
+  papersUpdated: t.integer().notNull().default(0),
+  papersFailed: t.integer().notNull().default(0),
+  success: t.integer({ mode: "boolean" }).notNull().default(false),
+  errorMessage: t.text(),
+  ...rowTimestampColumns(t),
+}));
+
 export type AuthorsTable = typeof authors;
 export type PapersTable = typeof papers;
 export type KeywordsTable = typeof keywords;

--- a/packages/db/tests/sync.test.ts
+++ b/packages/db/tests/sync.test.ts
@@ -1,0 +1,147 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { createDb, type Db } from "../src/client";
+import {
+  finishSyncRun,
+  insertSyncRunStart,
+  selectLatestSyncRun,
+} from "../src/queries/sync";
+
+const SYNC_RUNS_SCHEMA = `CREATE TABLE sync_runs (
+  sync_run_id INTEGER PRIMARY KEY,
+  runner TEXT NOT NULL,
+  started_at INTEGER NOT NULL,
+  finished_at INTEGER,
+  papers_seen INTEGER NOT NULL DEFAULT 0,
+  papers_new INTEGER NOT NULL DEFAULT 0,
+  papers_updated INTEGER NOT NULL DEFAULT 0,
+  papers_failed INTEGER NOT NULL DEFAULT 0,
+  success INTEGER NOT NULL DEFAULT 0,
+  error_message TEXT,
+  row_created_at INTEGER,
+  row_updated_at INTEGER
+)`;
+
+interface TestContext {
+  db: Db;
+  tempDir: string;
+}
+
+describe.sequential("sync run queries", () => {
+  let context: TestContext;
+
+  beforeEach(async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "lingbuzz-db-sync-"));
+    const dbPath = join(tempDir, "test.db");
+
+    const db = createDb({ url: `file:${dbPath}` });
+    await db.run(SYNC_RUNS_SCHEMA);
+
+    context = { db, tempDir };
+  });
+
+  afterEach(async () => {
+    await rm(context.tempDir, { recursive: true, force: true });
+  });
+
+  test("records a run start and reads back the finished row", async () => {
+    const startedAt = new Date("2026-07-04T10:00:00.000Z");
+    const finishedAt = new Date("2026-07-04T10:05:00.000Z");
+
+    const id = await insertSyncRunStart(context.db, {
+      runner: "local",
+      startedAt,
+    });
+    expect(id).toBeGreaterThan(0);
+
+    await finishSyncRun(context.db, id, {
+      finishedAt,
+      papersSeen: 42,
+      papersNew: 7,
+      papersUpdated: 3,
+      papersFailed: 1,
+      success: true,
+    });
+
+    const latest = await selectLatestSyncRun(context.db);
+    expect(latest).toBeDefined();
+    expect(latest?.syncRunId).toBe(id);
+    expect(latest?.runner).toBe("local");
+    expect(latest?.startedAt).toEqual(startedAt);
+    expect(latest?.finishedAt).toEqual(finishedAt);
+    expect(latest?.papersSeen).toBe(42);
+    expect(latest?.papersNew).toBe(7);
+    expect(latest?.papersUpdated).toBe(3);
+    expect(latest?.papersFailed).toBe(1);
+    expect(latest?.success).toBe(true);
+    expect(latest?.errorMessage).toBeNull();
+  });
+
+  test("selectLatestSyncRun returns the most recent run by startedAt", async () => {
+    const older = await insertSyncRunStart(context.db, {
+      runner: "gh-actions",
+      startedAt: new Date("2026-07-01T00:00:00.000Z"),
+    });
+    await finishSyncRun(context.db, older, {
+      finishedAt: new Date("2026-07-01T00:01:00.000Z"),
+      papersSeen: 1,
+      papersNew: 1,
+      papersUpdated: 0,
+      papersFailed: 0,
+      success: true,
+    });
+
+    const newer = await insertSyncRunStart(context.db, {
+      runner: "cf-worker",
+      startedAt: new Date("2026-07-03T00:00:00.000Z"),
+    });
+    await finishSyncRun(context.db, newer, {
+      finishedAt: new Date("2026-07-03T00:02:00.000Z"),
+      papersSeen: 5,
+      papersNew: 2,
+      papersUpdated: 1,
+      papersFailed: 0,
+      success: true,
+    });
+
+    const latest = await selectLatestSyncRun(context.db);
+    expect(latest?.syncRunId).toBe(newer);
+    expect(latest?.runner).toBe("cf-worker");
+  });
+
+  test("an unfinished run is visible with finishedAt null", async () => {
+    const startedAt = new Date("2026-07-05T12:00:00.000Z");
+    const id = await insertSyncRunStart(context.db, {
+      runner: "local",
+      startedAt,
+    });
+
+    const latest = await selectLatestSyncRun(context.db);
+    expect(latest?.syncRunId).toBe(id);
+    expect(latest?.finishedAt).toBeNull();
+    expect(latest?.success).toBe(false);
+    expect(latest?.papersSeen).toBe(0);
+  });
+
+  test("records an error message on a failed run", async () => {
+    const id = await insertSyncRunStart(context.db, {
+      runner: "local",
+      startedAt: new Date("2026-07-06T08:00:00.000Z"),
+    });
+    await finishSyncRun(context.db, id, {
+      finishedAt: new Date("2026-07-06T08:00:30.000Z"),
+      papersSeen: 0,
+      papersNew: 0,
+      papersUpdated: 0,
+      papersFailed: 0,
+      success: false,
+      errorMessage: "network unreachable",
+    });
+
+    const latest = await selectLatestSyncRun(context.db);
+    expect(latest?.success).toBe(false);
+    expect(latest?.errorMessage).toBe("network unreachable");
+  });
+});

--- a/packages/scraper/src/index.ts
+++ b/packages/scraper/src/index.ts
@@ -179,8 +179,8 @@ async function main(): Promise<void> {
       );
     }
 
-    printStats();
     success = true;
+    printStats();
   } catch (error) {
     errorMessage = error instanceof Error ? error.message : String(error);
     throw error;

--- a/packages/scraper/src/index.ts
+++ b/packages/scraper/src/index.ts
@@ -1,4 +1,5 @@
 import { createDb, type Db } from "@lingbuzz/db";
+import { finishSyncRun, insertSyncRunStart } from "@lingbuzz/db/queries/sync";
 import { CHUNK_SIZE } from "./constants";
 import { classifyRows, type ScrapeAction } from "./detect";
 import { fetchListingPage, generateListingUrls } from "./listing";
@@ -12,6 +13,8 @@ interface ScrapeStats {
   failed: number;
   fullScrapes: number;
   pagesProcessed: number;
+  // Total listing rows examined across all pages processed this run.
+  papersSeen: number;
   skipped: number;
   startTime: number;
   versionUpdates: number;
@@ -20,6 +23,7 @@ interface ScrapeStats {
 const stats: ScrapeStats = {
   startTime: Date.now(),
   pagesProcessed: 0,
+  papersSeen: 0,
   fullScrapes: 0,
   versionUpdates: 0,
   skipped: 0,
@@ -63,6 +67,51 @@ async function processAction(db: Db, action: ScrapeAction): Promise<void> {
   }
 }
 
+/**
+ * Records the start of a Sync run. Recording failures are logged but never
+ * crash the scrape, so a missing sync_runs table degrades gracefully.
+ */
+async function startSyncRun(
+  db: Db,
+  runner: string
+): Promise<number | undefined> {
+  try {
+    return await insertSyncRunStart(db, { runner, startedAt: new Date() });
+  } catch (error) {
+    logger.error("Failed to record sync run start", error);
+    return undefined;
+  }
+}
+
+/**
+ * Fills in the outcome of a Sync run, mapping the accumulated scrape stats.
+ * A missing start id or a recording failure is logged and ignored.
+ */
+async function completeSyncRun(
+  db: Db,
+  syncRunId: number | undefined,
+  success: boolean,
+  errorMessage: string | undefined
+): Promise<void> {
+  if (syncRunId === undefined) {
+    return;
+  }
+
+  try {
+    await finishSyncRun(db, syncRunId, {
+      finishedAt: new Date(),
+      papersSeen: stats.papersSeen,
+      papersNew: stats.fullScrapes,
+      papersUpdated: stats.versionUpdates,
+      papersFailed: stats.failed,
+      success,
+      errorMessage,
+    });
+  } catch (error) {
+    logger.error("Failed to record sync run completion", error);
+  }
+}
+
 function printStats(): void {
   const durationMs = Date.now() - stats.startTime;
   const durationSec = (durationMs / 1000).toFixed(2);
@@ -97,33 +146,47 @@ async function main(): Promise<void> {
     authToken: process.env.TURSO_AUTH_TOKEN,
   });
 
-  const urls = await generateListingUrls();
-  logger.info(`Generated ${urls.length} listing page URLs`);
+  const runner = process.env.SYNC_RUNNER ?? "local";
+  const syncRunId = await startSyncRun(db, runner);
 
-  for (const url of urls) {
-    const rows = await fetchListingPage(url);
-    const actions = await classifyRows(db, rows);
+  let success = false;
+  let errorMessage: string | undefined;
+  try {
+    const urls = await generateListingUrls();
+    logger.info(`Generated ${urls.length} listing page URLs`);
 
-    const actionable = actions.filter((a) => a.action !== "skip");
-    stats.pagesProcessed++;
+    for (const url of urls) {
+      const rows = await fetchListingPage(url);
+      const actions = await classifyRows(db, rows);
 
-    if (!fullMode && actionable.length === 0) {
+      const actionable = actions.filter((a) => a.action !== "skip");
+      stats.pagesProcessed++;
+      stats.papersSeen += rows.length;
+
+      if (!fullMode && actionable.length === 0) {
+        logger.info(
+          `No actionable rows on page ${stats.pagesProcessed}, stopping incremental scrape`
+        );
+        break;
+      }
+
       logger.info(
-        `No actionable rows on page ${stats.pagesProcessed}, stopping incremental scrape`
+        `Page ${stats.pagesProcessed}: ${actionable.length} actionable / ${rows.length} total rows`
       );
-      break;
+
+      await mapWithConcurrency(actions, CHUNK_SIZE, (action) =>
+        processAction(db, action)
+      );
     }
 
-    logger.info(
-      `Page ${stats.pagesProcessed}: ${actionable.length} actionable / ${rows.length} total rows`
-    );
-
-    await mapWithConcurrency(actions, CHUNK_SIZE, (action) =>
-      processAction(db, action)
-    );
+    printStats();
+    success = true;
+  } catch (error) {
+    errorMessage = error instanceof Error ? error.message : String(error);
+    throw error;
+  } finally {
+    await completeSyncRun(db, syncRunId, success, errorMessage);
   }
-
-  printStats();
 }
 
 await main();


### PR DESCRIPTION
## Summary

Implements **Plan 004** (#49): records every scraper Sync run and exposes the latest via the API, giving the frontend freshness indicator ground truth.

- **DB** — new `sync_runs` table; `queries/sync.ts` with `insertSyncRunStart` / `finishSyncRun` / `selectLatestSyncRun` (all take `db` first, per the post-003 factory convention); exports-map entry; generated migration containing only `CREATE TABLE sync_runs`.
- **Scraper** — `main()` inserts a start row (`runner` from `SYNC_RUNNER ?? "local"`) and finishes it in a `try/catch/finally`, mapping stats: `papersSeen` = total listing rows examined, `papersNew` = fullScrapes, `papersUpdated` = versionUpdates, `papersFailed` = failed, plus `success` / `errorMessage`. Recording is catch-log-continue, so it never crashes the scrape.
- **API** — `GET /sync/latest` returns `{ data: { runner, startedAt, finishedAt, papersNew, papersUpdated, success } }`, or 404 `{ error: "No sync runs recorded" }`. Mounted at `/sync`.

## Tests

Written test-first (verified red → green):
- `packages/db/tests/sync.test.ts` — start → finish → latest, latest-of-several, unfinished run (`finishedAt` null), error message.
- `apps/api/tests/sync.test.ts` — 200 projection shape, 404 when empty.

## Verification

- db 9/9, api 18/18, scraper 81/81 (each suite in isolation)
- all three `typecheck` exit 0; `bun run check` clean

## Operator actions after merge

Not in this PR (per plan):
1. `bun run db:migrate` against production Turso (applies the migration)
2. Deploy the API (`cd apps/api && bunx wrangler deploy`)

Plan 005 (cron) depends on both.

Part of #45. Closes #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)